### PR TITLE
Add documentation for gentest (and a small bugfix)

### DIFF
--- a/gentest/commands.go
+++ b/gentest/commands.go
@@ -19,7 +19,7 @@ func CompareCommands(exp []string, act []*exec.Cmd) error {
 		e := exp[i]
 		a := strings.Join(c.Args, " ")
 		if a != e {
-			return fmt.Errorf("expect %q got %q", a, e)
+			return fmt.Errorf("expect %q got %q", e, a)
 		}
 	}
 	return nil

--- a/gentest/commands.go
+++ b/gentest/commands.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-// CompareCommands ...
+// CompareCommands asserts that the expected commands match the actual commands
+// executed. The expected commands should be the commands, with arguments, as
+// you would type them on the command line. In typical usage, the actual
+// commands can be extracted from a genny#Generator.Results under the Commands
+// key
 func CompareCommands(exp []string, act []*exec.Cmd) error {
 	if len(exp) != len(act) {
 		return fmt.Errorf("len(exp) != len(act) [%d != %d]", len(exp), len(act))

--- a/gentest/files.go
+++ b/gentest/files.go
@@ -7,7 +7,10 @@ import (
 	"github.com/gobuffalo/genny"
 )
 
-// CompareFiles ...
+// CompareFiles compares a slice of expected filenames to a slice of
+// genny.Files. Expected files can be listed in any order. An excellent choice
+// for the actual files can be found in genny#Generator.Results under the Files
+// attribute
 func CompareFiles(exp []string, act []genny.File) error {
 	if len(exp) != len(act) {
 		return fmt.Errorf("len(exp) != len(act) [%d != %d]", len(exp), len(act))

--- a/gentest/logger.go
+++ b/gentest/logger.go
@@ -19,8 +19,10 @@ const (
 	PRINT        = "PRIN"
 )
 
+// compile-time assertion to guarantee Logger conforms to genny.Logger
 var _ genny.Logger = &Logger{}
 
+// NewLogger produces an initialized Logger
 func NewLogger() *Logger {
 	l := &Logger{
 		Stream: &bytes.Buffer{},
@@ -30,15 +32,30 @@ func NewLogger() *Logger {
 	return l
 }
 
+// Logger is a repository of log messages emitted by Generators suitable for
+// examination in tests.
 type Logger struct {
-	Stream  *bytes.Buffer
-	Log     map[string][]string
+	// Stream contains the raw byte stream from all logging activity. This is
+	// useful for output with testing.(*T).Log in concert with checking for
+	// testing.Verbose()
+	Stream *bytes.Buffer
+
+	// Log contains all log messages, categorized by log level. The keys of this
+	// map are the log levels found in the const definitions.
+	Log map[string][]string
+
+	// PrintFn is an optional func which will be invoked with all log messages
+	// when they are emitted
 	PrintFn func(...interface{})
+
+	// CloseFn is an optional cleanup function invoked at the end of the runner's
+	// execution
 	CloseFn func() error
 	moot    *sync.Mutex
 }
 
-// Close ...
+// Close is invoked at the end of a genny#Runner's execution. It will invoke a
+// CloseFn if set.
 func (l *Logger) Close() error {
 	if l.CloseFn == nil {
 		return nil
@@ -65,58 +82,84 @@ func (l *Logger) log(lvl string, args ...interface{}) {
 	}
 }
 
+// Debugf processes a format string and produces a debug message to the test
+// logger
 func (l *Logger) Debugf(s string, args ...interface{}) {
 	l.logf(DEBUG, s, args...)
 }
 
+// Debug combines a variadic number of strings into a single debug log message
 func (l *Logger) Debug(args ...interface{}) {
 	l.log(DEBUG, args...)
 }
 
+// Infof processes a format string and produces a log message at the Info level
 func (l *Logger) Infof(s string, args ...interface{}) {
 	l.logf(INFO, s, args...)
 }
 
+// Info combines a variadic number of strings into a log message at the Info
+// level.
 func (l *Logger) Info(args ...interface{}) {
 	l.log(INFO, args...)
 }
 
+// Printf logs messages at the Print level after processing the string and its
+// arguments as a format string
 func (l *Logger) Printf(s string, args ...interface{}) {
 	l.logf(PRINT, s, args...)
 }
 
+// Print logs messages at the Print level after combining all arguments into a
+// single string
 func (l *Logger) Print(args ...interface{}) {
 	l.log(PRINT, args...)
 }
 
+// Warnf logs messages at the Warn level after processing the string as a
+// format string against the provided arguments
 func (l *Logger) Warnf(s string, args ...interface{}) {
 	l.logf(WARN, s, args...)
 }
 
+// Warn logs messages at the Warn level after combining the provided arguments
+// into a single string
 func (l *Logger) Warn(args ...interface{}) {
 	l.log(WARN, args...)
 }
 
+// Errorf logs the provided string at the warning level. Prior to logging, the
+// string is processed as a format string against the provided arguments
 func (l *Logger) Errorf(s string, args ...interface{}) {
 	l.logf(ERROR, s, args...)
 }
 
+// Error logs a message formed by combining the arguments into a single string
+// at the Error level
 func (l *Logger) Error(args ...interface{}) {
 	l.log(ERROR, args...)
 }
 
+// Fatalf logs the provided string at the Fatal level. Prior to logging, the
+// string is processed as a format string against the provided arguments
 func (l *Logger) Fatalf(s string, args ...interface{}) {
 	l.logf(FATAL, s, args...)
 }
 
+// Fatal logs a message formed by combining the arguments into a single string
+// at the Fatal level
 func (l *Logger) Fatal(args ...interface{}) {
 	l.log(FATAL, args...)
 }
 
+// Panicf logs the provided string at the Panic level. Prior to logging, the
+// string is processed as a format string against the provided arguments
 func (l *Logger) Panicf(s string, args ...interface{}) {
 	l.logf(PANIC, s, args...)
 }
 
+// Panic logs a message formed by combining the arguments into a single string
+// at the Panic level
 func (l *Logger) Panic(args ...interface{}) {
 	l.log(PANIC, args...)
 }

--- a/gentest/runner.go
+++ b/gentest/runner.go
@@ -14,12 +14,12 @@ func NewRunner() *genny.Runner {
 	return r
 }
 
-// Run the generator and return results or an error
+// Run executes the generator and returns results or an error
 func Run(g *genny.Generator) (genny.Results, error) {
 	return RunNew(g, nil)
 }
 
-// RunNew the generator and return results or an error
+// RunNew executes the generator and returns results or an error
 func RunNew(g *genny.Generator, err error) (genny.Results, error) {
 	if err != nil {
 		return genny.Results{}, errors.WithStack(err)


### PR DESCRIPTION
The `gentest` package didn't have any documentation, which made me sad, since it made writing tests for generators *much* nicer. This adds a bunch of documentation from what I could find poking around the source.

Loving Genny so far! I'm using it to replace my terrible pile-o-bash for managing `GOPATH` over here: https://github.com/timraymond/genv (very early stages)