### PR TITLE
quick and dirty implementation of selective fs

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -72,7 +72,7 @@ func Test_Generator_FS(t *testing.T) {
 
 	res := run.Results()
 	r.Len(res.Commands, 0)
-	r.Len(res.Files, 2)
+	r.Len(res.Files, 8)
 
 	f := res.Files[0]
 	r.Equal("bar/baz.txt", f.Name())
@@ -81,6 +81,369 @@ func Test_Generator_FS(t *testing.T) {
 	f = res.Files[1]
 	r.Equal("foo.txt", f.Name())
 	r.Equal("foo!", f.String())
+}
+
+func Test_Generator_OnlyFS(t *testing.T) {
+	td := []struct {
+		name          string
+		includePrefix []string
+		includeSuffix []string
+		fs            []struct {
+			name    string
+			content string
+		}
+	}{
+		{
+			name:          "nil_nil",
+			includePrefix: nil,
+			includeSuffix: nil,
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+				{name: "sky/sun/light", content: "sun-light"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+		{
+			name:          "one_nil",
+			includePrefix: []string{"sky/star"},
+			includeSuffix: []string{},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+			},
+		},
+		{
+			name:          "many_nil",
+			includePrefix: []string{"sky/star", "sky/sun"},
+			includeSuffix: []string{},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+				{name: "sky/sun/light", content: "sun-light"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+		{
+			name:          "nil_one",
+			includePrefix: nil,
+			includeSuffix: []string{"light.txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+		{
+			name:          "one_one",
+			includePrefix: []string{"sky/s"},
+			includeSuffix: []string{"light"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/sun/light", content: "sun-light"},
+			},
+		},
+		{
+			name:          "many_one",
+			includePrefix: []string{"sky/.moon", "sky/sun", "sky/comet"},
+			includeSuffix: []string{"light"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/sun/light", content: "sun-light"},
+			},
+		},
+		{
+			name:          "nil_many",
+			includePrefix: nil,
+			includeSuffix: []string{"light", "t.txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+				{name: "sky/sun/light", content: "sun-light"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+		{
+			name:          "one_many",
+			includePrefix: []string{"sky/.moon"},
+			includeSuffix: []string{"light", "txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+			},
+		},
+		{
+			name:          "many_many",
+			includePrefix: []string{"sky/star", "sky/.moon"},
+			includeSuffix: []string{"light", "txt", "exe"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+			},
+		},
+	}
+
+	for _, tc := range td {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+
+			g := New()
+			r.NoError(g.OnlyFS(testdata.Data(), tc.includePrefix, tc.includeSuffix))
+
+			run := DryRunner(context.Background())
+			r.NoError(run.With(g))
+			r.NoError(run.Run())
+
+			res := run.Results()
+			r.Len(res.Commands, 0)
+			r.Len(res.Files, len(tc.fs))
+
+			for no, fe := range tc.fs {
+				f := res.Files[no]
+				r.Equal(fe.name, f.Name())
+				r.Equal(fe.content, f.String())
+			}
+		})
+	}
+}
+
+func Test_Generator_ExceptFS(t *testing.T) {
+	td := []struct {
+		name          string
+		excludePrefix []string
+		excludeSuffix []string
+		fs            []struct {
+			name    string
+			content string
+		}
+	}{
+		{
+			name:          "nil_nil",
+			excludePrefix: nil,
+			excludeSuffix: nil,
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+				{name: "sky/sun/light", content: "sun-light"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+		{
+			name:          "one_nil",
+			excludePrefix: []string{"sky/star"},
+			excludeSuffix: []string{},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+				{name: "sky/sun/light", content: "sun-light"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+		{
+			name:          "many_nil",
+			excludePrefix: []string{"sky/star", "sky/sun"},
+			excludeSuffix: []string{},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+			},
+		},
+		{
+			name:          "nil_one",
+			excludePrefix: nil,
+			excludeSuffix: []string{"txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/sun/light", content: "sun-light"},
+			},
+		},
+		{
+			name:          "one_one",
+			excludePrefix: []string{"sky/s"},
+			excludeSuffix: []string{".txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/.moon/light.txt", content: "moon-light.txt"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/sun/light", content: "sun-light"},
+			},
+		},
+		{
+			name:          "many_one",
+			excludePrefix: []string{"sky/.moon", "sky/sun", "___"},
+			excludeSuffix: []string{".txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+				{name: "sky/sun/light", content: "sun-light"},
+			},
+		},
+		{
+			name:          "nil_many",
+			excludePrefix: nil,
+			excludeSuffix: []string{"light", "txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{},
+		},
+		{
+			name:          "one_many",
+			excludePrefix: []string{"sky/.moon"},
+			excludeSuffix: []string{"light", "txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/star/light.txt", content: "star-light.txt"},
+				{name: "sky/sun/light", content: "sun-light"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+		{
+			name:          "many_many",
+			excludePrefix: []string{"sky/star", "sky/.moon"},
+			excludeSuffix: []string{"_____", "txt"},
+			fs: []struct {
+				name    string
+				content string
+			}{
+				{name: "bar/baz.txt", content: "baz!"},
+				{name: "foo.txt", content: "foo!"},
+				{name: "sky/.moon/light", content: "moon-light"},
+				{name: "sky/star/light", content: "star-light"},
+				{name: "sky/sun/light", content: "sun-light"},
+				{name: "sky/sun/light.txt", content: "sun-light.txt"},
+			},
+		},
+	}
+
+	for _, tc := range td {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+
+			g := New()
+			r.NoError(g.ExceptFS(testdata.Data(), tc.excludePrefix, tc.excludeSuffix))
+
+			run := DryRunner(context.Background())
+			r.NoError(run.With(g))
+			r.NoError(run.Run())
+
+			res := run.Results()
+			r.Len(res.Commands, 0)
+			r.Len(res.Files, len(tc.fs))
+
+			for no, fe := range tc.fs {
+				f := res.Files[no]
+				r.Equal(fe.name, f.Name())
+				r.Equal(fe.content, f.String())
+			}
+		})
+	}
+}
+
+func Test_Generator_SelectiveFS(t *testing.T) {
+	r := require.New(t)
+
+	includePrefix := []string{"sky"}
+	includeSuffix := []string{"txt"}
+	excludePrefix := []string{"sky/.moon"}
+	excludeSuffix := []string{}
+
+	g := New()
+	r.NoError(g.SelectiveFS(testdata.Data(), includePrefix, includeSuffix, excludePrefix, excludeSuffix))
+
+	run := DryRunner(context.Background())
+	r.NoError(run.With(g))
+	r.NoError(run.Run())
+
+	res := run.Results()
+	r.Len(res.Commands, 0)
+	r.Len(res.Files, 2)
+
+	td := []struct {
+		no      int
+		name    string
+		content string
+	}{
+		{name: "sky/star/light.txt", content: "star-light.txt"},
+		{name: "sky/sun/light.txt", content: "sun-light.txt"},
+	}
+	for no, te := range td {
+		f := res.Files[no]
+		r.Equal(te.name, f.Name())
+		r.Equal(te.content, f.String())
+	}
 }
 
 func Test_Command(t *testing.T) {

--- a/internal/testdata/sky/.moon/light
+++ b/internal/testdata/sky/.moon/light
@@ -1,0 +1,1 @@
+moon-light

--- a/internal/testdata/sky/.moon/light.txt
+++ b/internal/testdata/sky/.moon/light.txt
@@ -1,0 +1,1 @@
+moon-light.txt

--- a/internal/testdata/sky/star/light
+++ b/internal/testdata/sky/star/light
@@ -1,0 +1,1 @@
+star-light

--- a/internal/testdata/sky/star/light.txt
+++ b/internal/testdata/sky/star/light.txt
@@ -1,0 +1,1 @@
+star-light.txt

--- a/internal/testdata/sky/sun/light
+++ b/internal/testdata/sky/sun/light
@@ -1,0 +1,1 @@
+sun-light

--- a/internal/testdata/sky/sun/light.txt
+++ b/internal/testdata/sky/sun/light.txt
@@ -1,0 +1,1 @@
+sun-light.txt

--- a/internal/testdata/testdata.go
+++ b/internal/testdata/testdata.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-//go:embed foo.txt bar/*
+//go:embed foo.txt bar/* sky/*
 var testdata embed.FS
 
 func Data() fs.FS {


### PR DESCRIPTION
Implemented a quick and dirty selective filesystem to support including/excluding option that can be used as an alternative of `Generator.FS()`.

The current implementation of the Generator/Runner filesystem opens all files under the root when it is initialized. This is dangerous behavior and it introduced the `too many open files` error of `buffalo fix`.

For more background information could be found in https://github.com/gobuffalo/cli/issues/116#issuecomment-1065926318

Please take a look at this PR and please release it as a new version. Then I will open a new PR for cli.