### PR TITLE
removed dependencies on markbates/{safe,oncer}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,4 @@
 TAGS ?= ""
 
-tidy:
-	go mod tidy
-
 test:
-	go test -cover -tags ${TAGS} ./...
-	make tidy
-
+	go test -cover -race -tags ${TAGS} ./...

--- a/SHOULDERS.md
+++ b/SHOULDERS.md
@@ -1,28 +1,43 @@
-# github.com/gobuffalo/genny Stands on the Shoulders of Giants
+# genny Stands on the Shoulders of Giants
 
-github.com/gobuffalo/genny does not try to reinvent the wheel! Instead, it uses the already great wheels developed by the Go community and puts them all together in the best way possible. Without these giants, this project would not be possible. Please make sure to check them out and thank them for all of their hard work.
+genny does not try to reinvent the wheel! Instead, it uses the already great wheels developed by the Go community and puts them all together in the best way possible. Without these giants, this project would not be possible. Please make sure to check them out and thank them for all of their hard work.
 
 Thank you to the following **GIANTS**:
 
-
-* [github.com/gobuffalo/envy](https://godoc.org/github.com/gobuffalo/envy)
-
+* [github.com/aymerick/douceur](https://godoc.org/github.com/aymerick/douceur)
+* [github.com/davecgh/go-spew](https://godoc.org/github.com/davecgh/go-spew)
+* [github.com/fatih/structs](https://godoc.org/github.com/fatih/structs)
 * [github.com/gobuffalo/flect](https://godoc.org/github.com/gobuffalo/flect)
-
+* [github.com/gobuffalo/github_flavored_markdown](https://godoc.org/github.com/gobuffalo/github_flavored_markdown)
 * [github.com/gobuffalo/helpers](https://godoc.org/github.com/gobuffalo/helpers)
-
 * [github.com/gobuffalo/logger](https://godoc.org/github.com/gobuffalo/logger)
-
 * [github.com/gobuffalo/packd](https://godoc.org/github.com/gobuffalo/packd)
-
-* [github.com/gobuffalo/packr/v2](https://godoc.org/github.com/gobuffalo/packr/v2)
-
-* [github.com/gobuffalo/plush](https://godoc.org/github.com/gobuffalo/plush)
-
+* [github.com/gobuffalo/plush/v4](https://godoc.org/github.com/gobuffalo/plush/v4)
+* [github.com/gobuffalo/tags/v3](https://godoc.org/github.com/gobuffalo/tags/v3)
+* [github.com/gobuffalo/validate/v3](https://godoc.org/github.com/gobuffalo/validate/v3)
+* [github.com/gofrs/uuid](https://godoc.org/github.com/gofrs/uuid)
+* [github.com/gorilla/css](https://godoc.org/github.com/gorilla/css)
+* [github.com/kr/pretty](https://godoc.org/github.com/kr/pretty)
+* [github.com/kr/pty](https://godoc.org/github.com/kr/pty)
+* [github.com/kr/text](https://godoc.org/github.com/kr/text)
+* [github.com/microcosm-cc/bluemonday](https://godoc.org/github.com/microcosm-cc/bluemonday)
+* [github.com/pmezard/go-difflib](https://godoc.org/github.com/pmezard/go-difflib)
+* [github.com/sergi/go-diff](https://godoc.org/github.com/sergi/go-diff)
 * [github.com/sirupsen/logrus](https://godoc.org/github.com/sirupsen/logrus)
-
-* [github.com/spf13/cobra](https://godoc.org/github.com/spf13/cobra)
-
+* [github.com/sourcegraph/annotate](https://godoc.org/github.com/sourcegraph/annotate)
+* [github.com/sourcegraph/syntaxhighlight](https://godoc.org/github.com/sourcegraph/syntaxhighlight)
+* [github.com/stretchr/objx](https://godoc.org/github.com/stretchr/objx)
 * [github.com/stretchr/testify](https://godoc.org/github.com/stretchr/testify)
-
+* [github.com/yuin/goldmark](https://godoc.org/github.com/yuin/goldmark)
+* [golang.org/x/crypto](https://godoc.org/golang.org/x/crypto)
+* [golang.org/x/mod](https://godoc.org/golang.org/x/mod)
+* [golang.org/x/net](https://godoc.org/golang.org/x/net)
+* [golang.org/x/sync](https://godoc.org/golang.org/x/sync)
+* [golang.org/x/sys](https://godoc.org/golang.org/x/sys)
+* [golang.org/x/term](https://godoc.org/golang.org/x/term)
+* [golang.org/x/text](https://godoc.org/golang.org/x/text)
 * [golang.org/x/tools](https://godoc.org/golang.org/x/tools)
+* [golang.org/x/xerrors](https://godoc.org/golang.org/x/xerrors)
+* [gopkg.in/check.v1](https://godoc.org/gopkg.in/check.v1)
+* [gopkg.in/yaml.v2](https://godoc.org/gopkg.in/yaml.v2)
+* [gopkg.in/yaml.v3](https://godoc.org/gopkg.in/yaml.v3)

--- a/gentest/logger.go
+++ b/gentest/logger.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/gobuffalo/genny/v2"
-	"github.com/markbates/safe"
+	"github.com/gobuffalo/genny/v2/internal/safe"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/gobuffalo/logger v1.0.6
 	github.com/gobuffalo/packd v1.0.1
 	github.com/gobuffalo/plush/v4 v4.1.11
-	github.com/markbates/oncer v1.0.0
-	github.com/markbates/safe v1.0.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/tools v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -30,10 +30,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/markbates/oncer v1.0.0 h1:E83IaVAHygyndzPimgUYJjbshhDTALZyXxvk9FOlQRY=
-github.com/markbates/oncer v1.0.0/go.mod h1:Z59JA581E9GP6w96jai+TGqafHPW+cPfRxz2aSZ0mcI=
-github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
-github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
 github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -48,7 +44,6 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/safe/safe.go
+++ b/internal/safe/safe.go
@@ -3,11 +3,16 @@ package safe
 /* This is a copy of `gobuffalo/events/internal/safe/safe.go`, which was
    originally `markbates/safe/safe.go`. If you found any bug on this file,
    please fix the copies too.
+
+   This safeguard functions will be deprecated soon.
+   see https://github.com/gobuffalo/genny/pull/47 for more details.
 */
 
 import (
 	"errors"
 	"fmt"
+	"os"
+	"sync"
 )
 
 // Run the function safely knowing that if it panics
@@ -19,9 +24,16 @@ func Run(fn func()) (err error) {
 	})
 }
 
+var warningOnce sync.Once
+
+const warning = "WARNING! currently, genny recovers panic on the runner functions but the behavior will be dropped. please prepare your own recovery methods if you need them."
+
 // Run the function safely knowing that if it panics
 // the panic will be caught and returned as an error
 func RunE(fn func() error) (err error) {
+	warningOnce.Do(func() {
+		fmt.Fprintln(os.Stderr, warning)
+	})
 	defer func() {
 		if err != nil {
 			return

--- a/internal/safe/safe.go
+++ b/internal/safe/safe.go
@@ -1,0 +1,38 @@
+package safe
+
+/* This is a copy of `gobuffalo/events/internal/safe/safe.go`, which was
+   originally `markbates/safe/safe.go`. If you found any bug on this file,
+   please fix the copies too.
+*/
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Run the function safely knowing that if it panics
+// the panic will be caught and returned as an error
+func Run(fn func()) (err error) {
+	return RunE(func() error {
+		fn()
+		return nil
+	})
+}
+
+// Run the function safely knowing that if it panics
+// the panic will be caught and returned as an error
+func RunE(fn func() error) (err error) {
+	defer func() {
+		if err != nil {
+			return
+		}
+		if ex := recover(); ex != nil {
+			if e, ok := ex.(error); ok {
+				err = e
+				return
+			}
+			err = errors.New(fmt.Sprint(ex))
+		}
+	}()
+	return fn()
+}

--- a/runner.go
+++ b/runner.go
@@ -12,8 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/markbates/oncer"
-	"github.com/markbates/safe"
+	"github.com/gobuffalo/genny/v2/internal/safe"
 	"github.com/sirupsen/logrus"
 )
 
@@ -85,21 +84,6 @@ func (r *Runner) WithNew(g *Generator, err error) error {
 	}
 	r.With(g)
 	return nil
-}
-
-// WithFn will evaluate the function and if successful it will add
-// the Generator to the Runner, otherwise it will return the error
-// Deprecated
-func (r *Runner) WithFn(fn func() (*Generator, error)) error {
-	oncer.Deprecate(5, "genny.Runner#WithFn", "")
-	return safe.RunE(func() error {
-		g, err := fn()
-		if err != nil {
-			return err
-		}
-		r.With(g)
-		return nil
-	})
 }
 
 func (r *Runner) WithStep(name string, step *Step) error {

--- a/step.go
+++ b/step.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/markbates/safe"
+	"github.com/gobuffalo/genny/v2/internal/safe"
 )
 
 type DeleteFn func()

--- a/transformer.go
+++ b/transformer.go
@@ -1,7 +1,7 @@
 package genny
 
 import (
-	"github.com/markbates/safe"
+	"github.com/gobuffalo/genny/v2/internal/safe"
 )
 
 type TransformerFn func(File) (File, error)


### PR DESCRIPTION
align with https://github.com/gobuffalo/cli/pull/145 and https://github.com/gobuffalo/buffalo/pull/2260, removed dependencies on the following two packages:

* github.com/markbates/oncer
* github.com/markbates/safe

As a note, now we have the `safe.Run` in four places:

* `cli/internal/genny/build/validate.go` (as a form of `safeRun()`)
* `buffalo/worker/simple.go` (as a form of `safeRun()`)
* `genny/internal/safe/safe.go` (as a full `safe.go`)
* `events/internal/safe/safe.go` (as a full `safe.go`)

Note: a deprecated function `Runner.WithRn()` was dropped by this PR (breaking change). The function was marked as deprecated three years ago, and there is no reference to the function within the buffalo family.